### PR TITLE
remove spdx expression as they are not supported

### DIFF
--- a/dependency-review-config.yml
+++ b/dependency-review-config.yml
@@ -10,7 +10,7 @@ allow_licenses:
   - OpenSSL
   - Python-2.0
   - X11
-  - CC0-1.0 AND MIT
+  - CC0-1.0
   - CC-BY-4.0
 allow-dependencies-licenses:
   - 'pkg:githubactions/fossas/fossa-action'


### PR DESCRIPTION
### Proposed changes

From [reading the code](https://github.com/actions/dependency-review-action/blame/da24556b548a50705dd671f47852072ea4c105d9/src/licenses.ts#L39) and the issue that [added the code](https://github.com/actions/dependency-review-action/issues/907) spdx expressions are not supported.  Individual licenses should be listed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
