### PR TITLE
Add github.com/hashicorp/go-version to allow-dependencies-licenses

### DIFF
--- a/dependency-review-config.yml
+++ b/dependency-review-config.yml
@@ -18,4 +18,5 @@ allow-dependencies-licenses:
   - 'pkg:githubactions/opentofu/setup-opentofu'
   - 'pkg:golang/github.com/shoenig/go-m1cpu'
   - 'pkg:pypi/pytest-metadata'
+  - 'pkg:github.com/hashicorp/go-version'
 comment-summary-in-pr: on-failure

--- a/dependency-review-config.yml
+++ b/dependency-review-config.yml
@@ -18,5 +18,5 @@ allow-dependencies-licenses:
   - 'pkg:githubactions/opentofu/setup-opentofu'
   - 'pkg:golang/github.com/shoenig/go-m1cpu'
   - 'pkg:pypi/pytest-metadata'
-  - 'pkg:github.com/hashicorp/go-version'
+  - 'pkg:golang/github.com/hashicorp/go-version'
 comment-summary-in-pr: on-failure


### PR DESCRIPTION
### Proposed changes

Allow github.com/hashicorp/go-version package to be used even though license is MPL-2.0.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
